### PR TITLE
Bug fix related to a type error

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ analysis of simulations described in Bakan et al., 2012.
 Homepage
 --------
 
-http://prody.csb.pitt.edu/DruGUI/
+http://prody.csb.pitt.edu/drugui/
 
 Citation
 --------

--- a/drugui/druggability.py
+++ b/drugui/druggability.py
@@ -1171,7 +1171,7 @@ contain information on the chemical identity and physical properties of the
 probe molecules:
 
 * name: full chemical name
-* radius: average distance of the central atom other (moleule) heavy atoms
+* radius: average distance of the central atom other (molecule) heavy atoms
 * atomname: name of the central atom, used when writing PDB files
 * n_atoms: number of heavy atoms
 * charge: charge of the probe

--- a/drugui/druggability.py
+++ b/drugui/druggability.py
@@ -330,7 +330,7 @@ def get_histr(array, bins=10, **kwargs):
         histr += ' ' * r_width + ' #' + '-' * maxcount + '-#\n'
         for i, count in enumerate(counts):
             histr += format.format(ranges[i]).strip().rjust(r_width) + ' |'
-            histr += line * (count - 1) + marker * (count > 0)
+            histr += line * (count - 1) + marker * (int(count) > 0)
             histr += ' ' * (maxcount - count + 1) + '|\n'
 
         histr += ' ' * r_width + ' #' + '-' * maxcount + '-#\n'

--- a/drugui/drugui.tcl
+++ b/drugui/drugui.tcl
@@ -2117,7 +2117,7 @@ proc ::druggability::Write_python {} {
   puts $py_file "dia.set_parameters(temperature=$dia_temp) # K (productive simulation temperature)"
   puts $py_file "dia.set_parameters(delta_g=$dia_delta_g) # kcal/mol (probe binding hotspots with lower values will be evaluated)"
   puts $py_file "dia.set_parameters(n_probes=$dia_n_probes) # (number of probes to be merged to determine achievable affinity of a potential site)"
-  puts $py_file "dia.set_parameters(min_n_probes=$dia_min_n_probes) # (minimum number of probes to be merged for an acceptable soltuion)"
+  puts $py_file "dia.set_parameters(min_n_probes=$dia_min_n_probes) # (minimum number of probes to be merged for an acceptable solution)"
   puts $py_file "dia.set_parameters(merge_radius=$dia_merge_radius) # A (distance within which two probes will be merged)"
   puts $py_file "dia.set_parameters(low_affinity=$dia_low_affinity) # microMolar (potential sites with affinity better than this value will be reported)"
   puts $py_file "dia.set_parameters(n_solutions=$dia_n_solutions) # (number of drug-size solutions to report for each potential binding site)"


### PR DESCRIPTION
There is a difference between how booleans on numpy ints and regular ints are handled. Without setting count as a regular int, we get a numpy boolean, which can't be multiplied by marker. Following the change we get a regular boolean and are multiplying it by 1 or 0 to include it or not. 

I accidentally have 2 commits for this because I initially said it was a fix for my computer only but then I wanted to change it to scrap that because Hongchun's computer needed the fix too and it made a new commit instead.

I also fixed a couple of typos in documentation strings or comments.