### PR TITLE
Causes program to crash in python 2.7.12

### DIFF
--- a/drugui/druggability.py
+++ b/drugui/druggability.py
@@ -330,7 +330,7 @@ def get_histr(array, bins=10, **kwargs):
         histr += ' ' * r_width + ' #' + '-' * maxcount + '-#\n'
         for i, count in enumerate(counts):
             histr += format.format(ranges[i]).strip().rjust(r_width) + ' |'
-            histr += line * (count - 1) + marker * (count > 0)
+            histr += line * (count - 1) + marker * int(count > 0)
             histr += ' ' * (maxcount - count + 1) + '|\n'
 
         histr += ' ' * r_width + ' #' + '-' * maxcount + '-#\n'


### PR DESCRIPTION
This needs to be cast to an int in order for the multiplication to work. I assume this is the intended purpose of this line.